### PR TITLE
Fix multiple marquees not being able to have different axis and reverse values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-easy-marquee",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://jagnani73.github.io/react-easy-marquee",
   "description": "A marquee component for React using CSS.",
   "author": {

--- a/src/animation.tsx
+++ b/src/animation.tsx
@@ -1,10 +1,10 @@
 import { AnimationProps } from "./types";
 
-const Animation = ({ axis, reverse, offset }: AnimationProps) => {
+const Animation = ({ axis, reverse, offset, id }: AnimationProps) => {
   return (
     <style>
       {`
-        @keyframes slide${offset} {
+        @keyframes m${id}slide${offset} {
           from {
             transform: translate${axis || "X"}(${offset * 100}%);
           }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ const Marquee = ({
   children,
 }: MarqueeComponentProps) => {
   const [animate, setAnimate] = useState<"running" | "paused">("running");
-  const [id, setId] = useState(0)
+  const [id, setId] = useState<number>(0);
   useEffect(() => {
     setId(marqueeCounter);
     marqueeCounter++;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Axis, Align, MarqueeProps, MarqueeComponentProps } from "./types";
 import Animation from "./animation";
+
+let marqueeCounter = 0;
 
 const Marquee = ({
   axis,
@@ -16,7 +18,11 @@ const Marquee = ({
   children,
 }: MarqueeComponentProps) => {
   const [animate, setAnimate] = useState<"running" | "paused">("running");
-
+  const [id, setId] = useState(0)
+  useEffect(() => {
+    setId(marqueeCounter);
+    marqueeCounter++;
+  }, []);
   const offsetValues: [-1, 0, 1] = [-1, 0, 1];
 
   return (
@@ -42,12 +48,17 @@ const Marquee = ({
             whiteSpace: "nowrap",
             overflow: "hidden",
             position: "absolute",
-            animation: `slide${offset} ${duration ?? 5000}ms linear infinite`,
+            animation: `m${id}slide${offset} ${duration ?? 5000}ms linear infinite`,
             animationPlayState: animate ?? "running",
             minWidth: "100%",
           }}
         >
-          <Animation reverse={reverse} offset={offset} axis={axis} />
+          <Animation 
+            reverse={reverse}
+            offset={offset}
+            axis={axis}
+            id={id} 
+          />
 
           <div
             style={{

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface AnimationProps {
   id: number;
 }
 
-export interface MarqueeComponentProps extends Omit<AnimationProps, "offset"> {
+export interface MarqueeComponentProps extends Omit<AnimationProps, "offset" | "id"> {
   align?: Align;
   background?: string;
   duration?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface AnimationProps {
   axis?: Axis;
   reverse?: boolean;
   offset: -1 | 0 | 1;
+  id: number;
 }
 
 export interface MarqueeComponentProps extends Omit<AnimationProps, "offset"> {


### PR DESCRIPTION
Before:
All instances of Marquee used the same keyframes animation name for each slide offset:
`slide-1`
`slide0`
`slide1`
Thus every Marquee would have the same animation behaviour as the last Marquee initialised.

Now:
Every new Marquee instance gets an id - starts at 0 and increments by 1 for each new Marquee. Thus the keyframe animation names for Marquee 0 become:
`m0slide-1`
`m0slide0`
`m0slide1`
And keyframe animation names for Marquee 1 become:
`m1slide-1`
`m1slide0`
`m1slide1`
Allowing each Marquee to have it's own animation behaviour (axis and reverse).

Notes:
Probably should be using css modules rather than style tags, but this is the quickest fix.